### PR TITLE
fixed : colon outside formatting string are skipped

### DIFF
--- a/gstring.go
+++ b/gstring.go
@@ -86,6 +86,8 @@ func gformat(format string, args map[string]interface{}) (string, []interface{})
 		case ':':
 			if in_format {
 				in_args = true
+			} else {
+				new_format = append(new_format, ch)
 			}
 		default:
 			if in_format {

--- a/gstring_test.go
+++ b/gstring_test.go
@@ -41,3 +41,10 @@ func TestFprintm(t *testing.T) {
 		t.Fatal("Expected 'k', got: ", b.String())
 	}
 }
+
+func TestWithColon(t *testing.T) {
+	out := Sprintm("test : {test}", map[string]interface{}{"test": "value"})
+	if out != "test : value" {
+		t.Fatal("Expected 'test : value', got: ", out)
+	}
+}


### PR DESCRIPTION
Hello, I found this little bug that I needed to fix.
The colon was skipped and not present in the output because the switch case treated it like it was always inside brackets.